### PR TITLE
feat: prepend new feedback to list after successful submit

### DIFF
--- a/src/modules/feedback/components/FeedbackFormModal/FeedbackFormModal.jsx
+++ b/src/modules/feedback/components/FeedbackFormModal/FeedbackFormModal.jsx
@@ -34,10 +34,10 @@ const FeedbackFormModal = ({ open, onClose, onSuccess }) => {
     initialValues: { rating: 0, name: '', text: '' },
     validationSchema,
     onSubmit: async (values, { resetForm }) => {
-      await submit(values);
+      const newFeedback = await submit(values);
       resetForm();
       onClose();
-      onSuccess();
+      onSuccess(newFeedback);
     },
   });
 

--- a/src/modules/feedback/components/FeedbackSection/FeedbackSection.jsx
+++ b/src/modules/feedback/components/FeedbackSection/FeedbackSection.jsx
@@ -13,7 +13,7 @@ const FeedbackSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isSuccessOpen, setIsSuccessOpen] = useState(false);
-  const { feedbacks, total, averageRating: averageRatingRaw, onIndexChange } = useFeedbacks();
+  const { feedbacks, total, averageRating: averageRatingRaw, onIndexChange, prependFeedback } = useFeedbacks();
   const averageRating = Number(averageRatingRaw);
 
   const theme = useTheme();
@@ -41,7 +41,10 @@ const FeedbackSection = () => {
     });
   }, [onIndexChange]);
 
-  const handleSuccess = () => setIsSuccessOpen(true);
+  const handleSuccess = (newFeedback) => {
+    prependFeedback(newFeedback);
+    setIsSuccessOpen(true);
+  };
 
   if (!feedbacks.length) return null;
 

--- a/src/modules/feedback/hooks/useFeedbacks.js
+++ b/src/modules/feedback/hooks/useFeedbacks.js
@@ -41,5 +41,12 @@ export const useFeedbacks = () => {
     [feedbacks.length, total, fetchPage]
   );
 
-  return { feedbacks, total, averageRating, isLoading, onIndexChange };
+  const prependFeedback = (feedback) => {
+    setFeedbacks((prev) => [feedback, ...prev]);
+    const newTotal = total + 1;
+    setTotal(newTotal);
+    setAverageRating(Math.round((averageRating * total + feedback.rating) / newTotal * 10) / 10);
+  };
+
+  return { feedbacks, total, averageRating, isLoading, onIndexChange, prependFeedback };
 };

--- a/src/modules/feedback/hooks/useSubmitFeedback.js
+++ b/src/modules/feedback/hooks/useSubmitFeedback.js
@@ -7,7 +7,7 @@ export const useSubmitFeedback = () => {
   const submit = async ({ name, text, rating }) => {
     setIsLoading(true);
     try {
-      await postFeedbackApi({ name, text, rating });
+      return await postFeedbackApi({ name, text, rating });
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- Після успішного POST `/feedbacks` новий відгук додається на початок списку без перезавантаження сторінки
- `useFeedbacks` отримав `prependFeedback`, який оновлює список, total та averageRating (округлений до десятих)
- `useSubmitFeedback.submit` тепер повертає об'єкт відгуку з бекенду (`{ id, name, text, rating, ... }`)
- `FeedbackFormModal` передає цей об'єкт через `onSuccess` → `FeedbackSection.handleSuccess` → `prependFeedback`

## Test plan
- [ ] Залишити відгук через форму — новий відгук з'являється першим у каруселі
- [ ] Перевірити, що averageRating та total оновлюються коректно
- [ ] Перевірити, що каруселі не скидається на початок після додавання